### PR TITLE
Patch links to dependencies after transfers to `creatis-myriad` organisation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vital"]
 	path = vital
-	url = https://github.com/nathanpainchaud/vital
+	url = https://github.com/vitalab/vital
 [submodule "XTab"]
 	path = XTab
 	url = https://github.com/nathanpainchaud/XTab

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/vitalab/vital
 [submodule "XTab"]
 	path = XTab
-	url = https://github.com/nathanpainchaud/XTab
+	url = https://github.com/creatis-myriad/XTab

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Welcome to the code repository for projects related to the *Deep manIfolD leArni
 
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![CI: Code Format](https://github.com/nathanpainchaud/didactic/actions/workflows/code-format.yml/badge.svg?branch=main)](https://github.com/nathanpainchaud/didactic/actions/workflows/code-format.yml?query=branch%3Amain)
+[![CI: Code Format](https://github.com/creatis-myriad/didactic/actions/workflows/code-format.yml/badge.svg?branch=main)](https://github.com/creatis-myriad/didactic/actions/workflows/code-format.yml?query=branch%3Amain)
 
-[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/nathanpainchaud/didactic/blob/dev/LICENSE)
+[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/creatis-myriad/didactic/blob/dev/LICENSE)
 
 ## Publications
 
@@ -36,7 +36,7 @@ divided according to what they're computing (e.g. clinical or anatomical metrics
 - [requirements](requirements): conda and pip requirement files, along with detailed instructions on how to setup a
 working environment in different conditions (local, cluster, etc.)
 
-- [vital](https://github.com/nathanpainchaud/vital/tree/dev/vital): a separate repository (included as a
+- [vital](https://github.com/creatis-myriad/vital/tree/dev/vital): a separate repository (included as a
 [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)), of generic PyTorch modules, losses and metrics
 functions, and other tooling (e.g. image processing, parameter groups) that are commonly used. Also contains the code
 for managing specialized medical imaging datasets, e.g. CAMUS, CARDINAL.
@@ -48,7 +48,7 @@ for managing specialized medical imaging datasets, e.g. CAMUS, CARDINAL.
 First, download the project's code:
 ```shell script
 # clone project
-git clone --recurse-submodules https://github.com/nathanpainchaud/didactic.git
+git clone --recurse-submodules https://github.com/creatis-myriad/didactic.git
 ```
 Next you have to install the project and its dependencies. The project's dependency management and packaging is handled
 by [`poetry`](https://python-poetry.org/) so the recommended way to install the project is in a virtual environment
@@ -100,8 +100,8 @@ pip install -e XTab/autogluon/core --no-deps \
 
 ### Data
 Next, navigate to the data folder for the
-[CARDINAL](https://github.com/nathanpainchaud/vital/tree/dev/vital/data/cardinal) dataset and follow the [instructions
-on how to download and prepare the data](https://github.com/nathanpainchaud/vital/tree/dev/vital/data/cardinal/README.md).
+[CARDINAL](https://github.com/creatis-myriad/vital/tree/dev/vital/data/cardinal) dataset and follow the [instructions
+on how to download and prepare the data](https://github.com/creatis-myriad/vital/tree/dev/vital/data/cardinal/README.md).
 
 ### Configuring a Run
 This project uses Hydra to handle the configuration of the
@@ -152,7 +152,7 @@ more information on how to configure Comet using environment variables or the co
 [Comet's configuration variables documentation](https://www.comet.ml/docs/python-sdk/advanced/#comet-configuration-variables).
 
 An example of a `.comet.config` file, with the appropriate fields to track experiments online, can be found
-[here](https://github.com/nathanpainchaud/vital/tree/dev/.comet.config). You can simply copy the file to the directory
+[here](https://github.com/creatis-myriad/vital/tree/dev/.comet.config). You can simply copy the file to the directory
 of your choice within your project (be sure not to commit your Comet API key!!!) and fill the values with your own Comet
 credentials and workspace setup.
 

--- a/didactic/config/experiment/cardinal/cardiac-multimodal-representation.yaml
+++ b/didactic/config/experiment/cardinal/cardiac-multimodal-representation.yaml
@@ -116,7 +116,7 @@ task:
   mt_by_attr: False
 
   tabular_tokenizer:
-    _target_: rtdl.FeatureTokenizer
+    _target_: didactic.models.tabular.TabularEmbedding
     d_token: ${task.embed_dim}
 
   time_series_tokenizer:

--- a/didactic/models/tabular.py
+++ b/didactic/models/tabular.py
@@ -1,0 +1,100 @@
+from typing import List, Optional
+
+import torch
+from rtdl_revisiting_models import CategoricalEmbeddings, LinearEmbeddings
+from torch import Tensor, nn
+
+
+def _all_or_none(values):
+    return all(x is None for x in values) or all(x is not None for x in values)
+
+
+class TabularEmbedding(nn.Module):
+    """Combines `LinearEmbeddings` and `CategoricalEmbeddings`.
+
+    The "Feature Tokenizer" module from "Revisiting Deep Learning Models for Tabular Data" by Gorishniy et al. (2021).
+    The module transforms continuous and categorical features to tokens (embeddings).
+
+    Notes:
+        - This is a port of the `FeatureTokenizer` class from v0.0.13 of the `rtdl` package using the updated underlying
+          `CategoricalEmbeddings` and `LinearEmbeddings` from v0.0.2 of the `rtdl_revisiting_models` package, instead of
+          the original `CategoricalFeatureTokenizer` and `NumericalFeatureTokenizer` from the `rtdl` package.
+
+    References:
+        - Original implementation is here: https://github.com/yandex-research/rtdl/blob/f395a2db37bac74f3a209e90511e2cb84e218973/rtdl/modules.py#L260-L377
+
+    Examples:
+        .. testcode::
+
+            n_objects = 4
+            n_num_features = 3
+            n_cat_features = 2
+            d_token = 7
+            x_num = torch.randn(n_objects, n_num_features)
+            x_cat = torch.tensor([[0, 1], [1, 0], [0, 2], [1, 1]])
+            # [2, 3] reflects cardinalities
+            tokenizer = FeatureTokenizer(n_num_features, [2, 3], d_token)
+            tokens = tokenizer(x_num, x_cat)
+            assert tokens.shape == (n_objects, n_num_features + n_cat_features, d_token)
+    """
+
+    def __init__(
+        self,
+        n_num_features: int,
+        cat_cardinalities: List[int],
+        d_token: int,
+    ) -> None:
+        """Initializes class instance.
+
+        Args:
+            n_num_features: the number of continuous features. Pass :code:`0` if there are no numerical features.
+            cat_cardinalities: the number of unique values for each feature. Pass an empty list if there are no
+                categorical features.
+            d_token: the size of one token.
+        """
+        super().__init__()
+        assert n_num_features >= 0, "n_num_features must be non-negative"
+        assert (
+            n_num_features or cat_cardinalities
+        ), "at least one of n_num_features or cat_cardinalities must be positive/non-empty"
+        self.num_tokenizer = LinearEmbeddings(n_num_features, d_token) if n_num_features else None
+        self.cat_tokenizer = CategoricalEmbeddings(cat_cardinalities, d_token) if cat_cardinalities else None
+
+    @property
+    def n_tokens(self) -> int:
+        """The number of tokens."""
+        return sum(x.n_tokens for x in [self.num_tokenizer, self.cat_tokenizer] if x is not None)
+
+    @property
+    def d_token(self) -> int:
+        """The size of one token."""
+        return self.cat_tokenizer.d_token if self.num_tokenizer is None else self.num_tokenizer.d_token  # type: ignore
+
+    def forward(self, x_num: Optional[Tensor], x_cat: Optional[Tensor]) -> Tensor:
+        """Perform the forward pass.
+
+        Args:
+            x_num: continuous features. Must be presented if :code:`n_num_features > 0` was passed to the constructor.
+            x_cat: categorical features. Must be presented if non-empty :code:`cat_cardinalities` was passed to the
+                constructor.
+
+        Returns:
+            tokens
+
+        Raises:
+            AssertionError: if the described requirements for the inputs are not met.
+        """
+
+        assert x_num is not None or x_cat is not None, "At least one of x_num and x_cat must be presented"
+        assert _all_or_none(
+            [self.num_tokenizer, x_num]
+        ), "If self.num_tokenizer is (not) None, then x_num must (not) be None"
+        assert _all_or_none(
+            [self.cat_tokenizer, x_cat]
+        ), "If self.cat_tokenizer is (not) None, then x_cat must (not) be None"
+        x = []
+        if self.num_tokenizer is not None:
+            x.append(self.num_tokenizer(x_num))
+        if self.cat_tokenizer is not None:
+            x.append(self.cat_tokenizer(x_cat))
+        return x[0] if len(x) == 1 else torch.cat(x, dim=1)

--- a/didactic/tasks/cardiac_multimodal_representation.py
+++ b/didactic/tasks/cardiac_multimodal_representation.py
@@ -6,10 +6,8 @@ from typing import Any, Callable, Dict, Literal, Optional, Sequence, Tuple
 
 import autogluon.multimodal.models.ft_transformer
 import hydra
-import rtdl
 import torch
 from omegaconf import DictConfig
-from rtdl import FeatureTokenizer
 from torch import Tensor, nn
 from torch.nn import Parameter, ParameterDict, init
 from torchmetrics.functional import accuracy, mean_absolute_error
@@ -21,7 +19,8 @@ from vital.data.cardinal.utils.attributes import TABULAR_CAT_ATTR_LABELS
 from vital.tasks.generic import SharedStepsTask
 from vital.utils.decorators import auto_move_data
 
-from didactic.models.layers import PositionalEncoding, SequencePooling
+from didactic.models.layers import CLSToken, PositionalEncoding, SequencePooling
+from didactic.models.tabular import TabularEmbedding
 from didactic.models.time_series import TimeSeriesEmbedding
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ class CardiacMultimodalRepresentationTask(SharedStepsTask):
         ordinal_mode: bool = True,
         contrastive_loss: Callable[[Tensor, Tensor], Tensor] | DictConfig = None,
         contrastive_loss_weight: float = 0,
-        tabular_tokenizer: Optional[FeatureTokenizer | DictConfig] = None,
+        tabular_tokenizer: Optional[TabularEmbedding | DictConfig] = None,
         time_series_tokenizer: Optional[TimeSeriesEmbedding | DictConfig] = None,
         cls_token: bool = True,
         sequence_pooling: bool = False,
@@ -269,7 +268,7 @@ class CardiacMultimodalRepresentationTask(SharedStepsTask):
 
         # Initialize parameters of method for reducing the dimensionality of the encoder's output to only one token
         if self.hparams.cls_token:
-            self.cls_token = rtdl.CLSToken(self.hparams.embed_dim, "uniform")
+            self.cls_token = CLSToken(self.hparams.embed_dim)
         if self.hparams.sequence_pooling:
             self.sequence_pooling = SequencePooling(self.hparams.embed_dim)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4484,25 +4484,18 @@ files = [
 ]
 
 [[package]]
-name = "rtdl"
-version = "0.0.14.dev0"
-description = "Research on Tabular Deep Learning."
+name = "rtdl-revisiting-models"
+version = "0.0.2"
+description = "Revisiting Deep Learning Models for Tabular Data."
 optional = false
-python-versions = ">=3.7"
-files = []
-develop = false
+python-versions = ">=3.8"
+files = [
+    {file = "rtdl_revisiting_models-0.0.2-py3-none-any.whl", hash = "sha256:12c9cc1fc7a950cececd977ed810ec336fb8354cab96cd858855ce8e8cbe6e0a"},
+    {file = "rtdl_revisiting_models-0.0.2.tar.gz", hash = "sha256:2f430e4ce612ceceff023b78720583dd3c425446f2ce8c34fe3ad413178050a6"},
+]
 
 [package.dependencies]
-numpy = ">=1.18,<2"
-scikit-learn = ">=1.0,<2"
-torch = ">=1.7,<3"
-typing-extensions = ">=4.0.1,<5"
-
-[package.source]
-type = "git"
-url = "https://github.com/nathanpainchaud/rtdl.git"
-reference = "torch-2.X-support"
-resolved_reference = "69d98de78c00ef18f7b8689558c97bc2fd464172"
+torch = ">=1.8,<3"
 
 [[package]]
 name = "s3transfer"
@@ -6124,4 +6117,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.6"
-content-hash = "27ceee30d77beacdbf3320dde3214580119a805487e06b4e277f8932068c5bc7"
+content-hash = "114e2ae8f42a7cb54385b202df4d9dbc6bd920ff55c20bd8a4b26437e51f7b69"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3156,13 +3156,13 @@ files = [
 
 [[package]]
 name = "pacmap"
-version = "0.7.1"
+version = "0.7.2"
 description = "The official implementation for PaCMAP: Pairwise Controlled Manifold Approximation Projection"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pacmap-0.7.1-py3-none-any.whl", hash = "sha256:a14fd68108b4a9f51454e6b190349d5f585de23985c9db82e6526dd549f1152c"},
-    {file = "pacmap-0.7.1.tar.gz", hash = "sha256:fad1ce6cc5ecaccfdbdd16522692a5b45f2f3d7af32fc77c47571b435012ad1d"},
+    {file = "pacmap-0.7.2-py3-none-any.whl", hash = "sha256:36b7d897cabe6bdb8a15ef630054ecbe51e0e2585c7b43c4b4bdd649750b73e7"},
+    {file = "pacmap-0.7.2.tar.gz", hash = "sha256:a86819db8b192c66ad43ecc8b52ab89f3d56852c08a109400ccf51fff2b22f72"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pandas = "*"
 torchmetrics = "*"
 PyYAML = "*"
 matplotlib = "*"
+pacmap = "*"
 comet-ml = "*"
 vital = { path = "./vital/", develop = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Deep manIfolD leArning CharacTerization In eChocardiography (DIDA
 authors = ["Nathan Painchaud <nathan.painchaud@usherbrooke.ca>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/nathanpainchaud/didactic"
+repository = "https://github.com/creatis-myriad/didactic"
 classifiers=[
     "Environment :: Console",
     "Natural Language :: English",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ python = "~3.10.6"
 torch = { version = "~2.0.0", source = "pytorch-cu118" }
 torchvision = { version = "~0.15.1", source = "pytorch-cu118" }
 pytorch-lightning = "~2.0.0"
-# Temporary workaround to install RTDL from my own fork, which relaxes an unecessarily strict constraint version that
-# prohibits PyTorch's 2-series
-rtdl = { git = "https://github.com/nathanpainchaud/rtdl.git", branch = "torch-2.X-support" }
+rtdl-revisiting-models = "~0.0.2"
 hydra-core = "~1.3.0"
 hydra-joblib-launcher = "*"
 holoviews = { version = "*", extras = ["recommended"] }


### PR DESCRIPTION
Also migrate `rtdl` dependency over to the new `rtdl_revisiting_models` package, copying and patching missing parts of the original API.